### PR TITLE
Implement comparison cycling and key deduplication

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -14,6 +14,8 @@ pub enum Hotkey {
     SkipKey,
     UndoKey,
     PauseKey,
+    SwitchComparisonPrevious,
+    SwitchComparisonNext,
     ToggleGlobalHotkeys,
 }
 
@@ -162,6 +164,8 @@ impl KeyState {
                         b"SkipKey" if in_profile => XmlExpect::Hotkey(Hotkey::SkipKey),
                         b"UndoKey" if in_profile => XmlExpect::Hotkey(Hotkey::UndoKey),
                         b"PauseKey" if in_profile => XmlExpect::Hotkey(Hotkey::PauseKey),
+                        b"SwitchComparisonPrevious" if in_profile => XmlExpect::Hotkey(Hotkey::SwitchComparisonPrevious),
+                        b"SwitchComparisonNext" if in_profile => XmlExpect::Hotkey(Hotkey::SwitchComparisonNext),
                         b"ToggleGlobalHotkeys" if in_profile => {
                             XmlExpect::Hotkey(Hotkey::ToggleGlobalHotkeys)
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,15 +148,13 @@ impl HotkeyListener {
                 _ => (),
             }
         }
-        // Always include "None" as a fallback option
+        // Always include "Personal Best"
         let mut enabled: Vec<&'static str> = Self::COMPARISONS
             .iter()
             .filter(|&&c| enabled_map.get(c).copied().unwrap_or(false))
             .copied()
             .collect();
-        if enabled.is_empty() || !enabled.contains(&"None") {
-            enabled.push("None");
-        }
+        enabled.push("Personal Best");
         Ok(enabled)
     }
 
@@ -188,27 +186,17 @@ impl HotkeyListener {
 
         let enabled_comparisons = Self::read_enabled_comparisons(self.args.settings.as_deref())?;
 
-        let mut enabled_indices: Vec<usize> = enabled_comparisons
+        let enabled_indices: Vec<usize> = enabled_comparisons
             .iter()
             .filter_map(|&name| {
-                if name == "None" {
-                    Some(Self::COMPARISON_COMMANDS.len() - 1)
-                } else {
                     Self::COMPARISONS.iter().position(|&c| c == name)
-                }
             })
             .collect();
-
-        let none_index = Self::COMPARISON_COMMANDS.len() - 1;
-        let none_enabled = enabled_indices.contains(&none_index);
-        if !none_enabled {
-            enabled_indices.retain(|&idx| idx != none_index);
-        }
 
         let last_comparison = Self::read_last_comparison(self.args.settings.as_deref())?
             .unwrap_or_else(|| "Personal Best".to_string());
 
-        let mut comparison_index = Self::COMPARISONS
+        let mut comparison_index = enabled_comparisons
             .iter()
             .position(|&c| c == last_comparison)
             .unwrap_or(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ impl HotkeyListener {
         }
 
         let last_comparison = Self::read_last_comparison(self.args.settings.as_deref())?
-            .unwrap_or_else(|| "Best Segments".to_string());
+            .unwrap_or_else(|| "Personal Best".to_string());
 
         let mut comparison_index = Self::COMPARISONS
             .iter()


### PR DESCRIPTION
I'm horrible with rust, just to make that clear.

Anyway, this request aims to add previous/next comparison cycling.
It will read the config file for the last used comparison, and set the start index to there.
It will wrap around either direction, and it will only use the comparisons that are currently enabled.

Caveats:
If the comparison is changed directly in livesplit, it will temporarily desync the cycle until the next change happens in live-split-hotkeys
If the enabled comparisons are changed, they are only written to disk once livesplit is closed, so livesplit and live-split-hotkeys will need to be re-opened.

Bonus:
Also uses a hashset to prevent duplicated keys from being handled. should fix #2 